### PR TITLE
Fix for calculating endLocation when using a container

### DIFF
--- a/lib/angular-smooth-scroll.js
+++ b/lib/angular-smooth-scroll.js
@@ -87,7 +87,7 @@
 				do {
 					location += element.offsetTop;
 					element = element.offsetParent;
-				} while (element);
+				} while (element && (!container || element.id!==container.id));
 			}
 			location = Math.max(location - offset, 0);
 			return location;


### PR DESCRIPTION
When scrolling within a container, e.g a div, we should stop traversing offsetParents when we reach the container itself - otherwise the location will be wrong.